### PR TITLE
make a few variables 'extern' for `make gtk` to succeed.

### DIFF
--- a/src/gtk234.c
+++ b/src/gtk234.c
@@ -44,23 +44,26 @@ extern int         hcopy_use_preset_values, hcopy_use_color, hcopy_print_now;
 extern char        hcopy_filename[80], hcopy_print_cmd[80];
 
 extern int     glsundo_ready;
+extern GtkWidget   *toplevel;
+extern GdkPixmap   *pixmap;
 
 /* function defined in gtkgls_utils.c */
 extern void move_win_to(GtkWidget *w, int x, int y);
 extern void set_title(GtkWidget *w, char *text);
+/* external variables defined in gtkgls_utils.c */
+extern GtkWidget *label;
 /* from gtkminig2 */
 extern int select_gw(int);
 
 GtkTextBuffer *output_text_buffer;
 GtkWidget     *output_text_view, *text_scrolled;
-GtkWidget     *toplevel, *menubar, *drawing_area_gls, *drawing_area_sp;
-GtkWidget     *toolbar, *pos_text, *label, *gls_scrolled, *sp_scrolled, *command_entry;
+GtkWidget     *menubar, *drawing_area_gls, *drawing_area_sp;
+GtkWidget     *toolbar, *pos_text, *gls_scrolled, *sp_scrolled, *command_entry;
 GtkWidget     *undo_button, *redo_button, *save_button, *zin_button, *zout_button;
 GtkWidget     *undo_menu_item, *redo_menu_item, *save_menu_item, *zout_menu_item;
 GtkWidget     *backg_button, *fwdg_button;
 GtkWidget     *backg_menu_item, *fwdg_menu_item;
 GtkTooltips   *tooltips;
-GdkPixmap     *pixmap;
 /* winpix = gls pixmap for zoom < 8; otherwise winpix = gls window */
 GdkWindow     *window, *winpix;
 Cursor    watchCursor;

--- a/src/gtkgls.c
+++ b/src/gtkgls.c
@@ -25,17 +25,18 @@ extern GdkFont     *font_id;
 extern GdkPoint    points[512];
 extern GdkColor    color_id[20];
 extern int         nstored, win_width, win_height, glsundo_ready;
+extern GtkWidget   *toplevel, *drawing_area;
+extern GdkPixmap   *pixmap;
 
 /* function defined in gtkgls_utils.c */
 extern void move_win_to(GtkWidget *w, int x, int y);
 
 GtkTextBuffer *output_text_buffer;
 GtkWidget     *output_text_view, *text_scrolled;
-GtkWidget     *toplevel, *menubar, *drawing_area, *toolbar, *scrolled, *pos_text;
+GtkWidget     *menubar, *toolbar, *scrolled, *pos_text;
 GtkWidget     *undo_button, *redo_button, *save_button, *zin_button, *zout_button;
 GtkWidget     *undo_menu_item, *redo_menu_item, *save_menu_item, *zout_menu_item;
 GtkTooltips   *tooltips;
-GdkPixmap     *pixmap;
 GdkWindow     *window;
 int       ww = 600, hh = 500, width = 600, height = 500;
 int       zoom = 1, scr_width, scr_height;


### PR DESCRIPTION
Dear Dr. Radford,

This is Kazuyoshi Furutaka of JAEA at home...
I propose to make a few variables in gtkgls.c and gtk234.c extern for `make gtk` to finish w/o errors.

Variables 'drawing_area', 'pixmap', and 'toplevel'
in gtkgls.c, and the latter two in gtk234.c, are already
defined in miniga.c.

Also, 'label' in gtk234.c is defined in gtkgls_utils.c.