### PR TITLE
remove "-lXp" from several Makefiles

### DIFF
--- a/src/Makefile.cygwin
+++ b/src/Makefile.cygwin
@@ -35,8 +35,8 @@
          RM_CMD = $(RM) *.o core *[~%] *.trace
 
            LIBS = -lX11 -lm -lreadline -lncurses
-     MOTIF_LIBS = -lXm -lMrm -lXt -lXext -lXp
-   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext -lXp
+     MOTIF_LIBS = -lXm -lMrm -lXt -lXext
+   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext
 
 # -----------------------------------------------------------------------
 #  UNCOMMENT and CHANGE (if necessary)  the line defining HISLIBS

--- a/src/Makefile.linux
+++ b/src/Makefile.linux
@@ -36,8 +36,8 @@
          RM_CMD = $(RM) *.o core* *[~%] *.trace
 
            LIBS = -lX11 -lm -lreadline -lncurses
-     MOTIF_LIBS = -lXm -lMrm -lXt -lXext -lXp
-   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext -lXp
+     MOTIF_LIBS = -lXm -lMrm -lXt -lXext
+   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext
 
 # -----------------------------------------------------------------------
 #  UNCOMMENT and CHANGE (if necessary)  the line defining HISLIBS

--- a/src/Makefile.macosx
+++ b/src/Makefile.macosx
@@ -35,8 +35,8 @@
          RM_CMD = $(RM) *.o core* *[~%] *.trace
 
            LIBS = -lX11 -lm -lreadline -lncurses
-     MOTIF_LIBS = -lXm -lMrm -lXt -lXext -lXp
-   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext -lXp
+     MOTIF_LIBS = -lXm -lMrm -lXt -lXext
+   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext
 
 # -----------------------------------------------------------------------
 #  UNCOMMENT and CHANGE (if necessary)  the line defining HISLIBS

--- a/src/Makefile.macosx_gtk
+++ b/src/Makefile.macosx_gtk
@@ -35,8 +35,8 @@
          RM_CMD = $(RM) *.o core* *[~%] *.trace
 
            LIBS = -lX11 -lm -lreadline -lncurses
-     MOTIF_LIBS = -lXm -lMrm -lXt -lXext -lXp
-   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext -lXp
+     MOTIF_LIBS = -lXm -lMrm -lXt -lXext
+   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext
 
 # -----------------------------------------------------------------------
 #  UNCOMMENT and CHANGE (if necessary)  the line defining HISLIBS

--- a/src/Makefile_gf3m
+++ b/src/Makefile_gf3m
@@ -35,8 +35,8 @@
          RM_CMD = $(RM) *.o core* *[~%] *.trace
 
            LIBS = -lX11 -lm -lreadline -lncurses
-     MOTIF_LIBS = -lXm -lMrm -lXt -lXext -lXp
-   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext -lXp
+     MOTIF_LIBS = -lXm -lMrm -lXt -lXext
+   STATIC_MOTIF = -lXm -lMrm -lXpm -lXt -lSM -lICE -lXext
 
 # -----------------------------------------------------------------------
 #  UNCOMMENT and CHANGE (if necessary)  the line defining HISLIBS


### PR DESCRIPTION
Dear Dr. Radford,

The Xprint library seems to have been removed and missing in recent Debian Linux as well as Cygwin (Fedora 35 still has libXp & libXp-devel packages).

Even without the option, `make xm` finishes w/o error and at least xmgf3 works well.

ref:
https://www.linuxquestions.org/questions/debian-26/libxp-and-libxp-devel-missing-in-debian-testing-stretch-4175582254/

Kazuyoshi